### PR TITLE
Update 2020-12-17-an-introduction-to-session-types.md

### DIFF
--- a/posts/2020-12-17-an-introduction-to-session-types.md
+++ b/posts/2020-12-17-an-introduction-to-session-types.md
@@ -822,7 +822,7 @@ So, did it work? Are we safe from the bad programs? Yes and no. Which, *uh*, kin
 
 $$
 \begin{array}{c}
-  (\nu x x')(\nu y y')%
+  (\nu x x')(\nu y y')
   \left(
   x(z).y\langle{z}\rangle.0 \parallel y'(w).x'\langle{w}\rangle.0
   \right)

--- a/posts/2020-12-17-an-introduction-to-session-types.md
+++ b/posts/2020-12-17-an-introduction-to-session-types.md
@@ -666,7 +666,7 @@ $$
   \quad
   \begin{array}{rl}
   \longrightarrow
-  & (\nu x)%
+  & (\nu x)
     \left(
     \begin{array}{l}
     {P_1}\parallel {Q_1}\{y_1/z_1\}\parallel
@@ -678,7 +678,7 @@ $$
   \mathit{or}
   \\
   \longrightarrow
-  & (\nu x)%
+  & (\nu x)
     \left(
     \begin{array}{l}
     {P_1}\parallel {Q_1}\{y_2/z_1\}\parallel
@@ -694,7 +694,7 @@ Another *fun* thing we can do is write two processes which echo a message on $x$
 
 $$
 \begin{array}{c}
-  (\nu x)%
+  (\nu x)
   \left(
   x(y).x\langle{y}\rangle.0 \parallel x(z).x\langle{z}\rangle.0
   \right)


### PR DESCRIPTION
On the web page where this is rendered, the latex expressions are put on a single long line.
That causes the comment signs '%' to comment out everything after it, and making
the latex not show as intended.  
The fix proposed here is to just remove the comment signs. 
An alternative is to not have the latex code turned into a single line,
but I don't know where in the process this happens.
Thanks for a great blog!