### PR TITLE
fix typo in example in intro-to-session-types.md

### DIFF
--- a/posts/2020-12-17-an-introduction-to-session-types.md
+++ b/posts/2020-12-17-an-introduction-to-session-types.md
@@ -1333,7 +1333,7 @@ $$
   \begin{array}{l}
   \bullet\;
     \begin{array}{l}
-    \mathbf{let} \; () = \mathbf{spawn} \; () \; \mathbf{in}
+    \mathbf{let} \; () = () \; \mathbf{in}
     \\
     \text{ada} \; a
     \end{array}


### PR DESCRIPTION
The `spawn` is removed by the rule.